### PR TITLE
Destroy route for Dragons

### DIFF
--- a/app/controllers/dragons_controller.rb
+++ b/app/controllers/dragons_controller.rb
@@ -1,12 +1,12 @@
 class DragonsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index]
+  before_action :set_dragon, only: [:show, :destroy]
 
   def index
     @dragons = Dragon.all
   end
 
   def show
-    @dragon = Dragon.find(params[:id])
   end
 
   def new
@@ -23,7 +23,16 @@ class DragonsController < ApplicationController
     end
   end
 
+  def destroy
+    @dragon.destroy
+    redirect_to dragons_path, status: :see_other
+  end
+
   private
+
+  def set_dragon
+    @dragon = Dragon.find(params[:id])
+  end
 
   def dragon_params
     params.require(:dragon).permit(:name, :location, :category, :price_per_day, :description, :seats, :age)

--- a/app/views/dragons/show.html.erb
+++ b/app/views/dragons/show.html.erb
@@ -39,4 +39,8 @@
     </div>
   </div>
 
+  <hr/>
+
+  <%= link_to 'Delete', dragon_path(@dragon), class: 'btn btn-danger text-light w-100', data: {turbo_method: :delete, turbo_confirm: "Are you sure you?"} %>
+
 </div>

--- a/app/views/dragons/show.html.erb
+++ b/app/views/dragons/show.html.erb
@@ -41,6 +41,6 @@
 
   <hr/>
 
-  <%= link_to 'Delete', dragon_path(@dragon), class: 'btn btn-danger text-light w-100', data: {turbo_method: :delete, turbo_confirm: "Are you sure you?"} %>
+  <%= link_to 'Delete', dragon_path(@dragon), class: 'btn btn-danger text-light w-100', data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
 
 </div>


### PR DESCRIPTION
Purpose:
As a user, I want to be able to delete dragons.

Specification:
- new 'delete' button on /dragons/:id (with confirmation prompt)
- refactor the dragons controller to set the current dragon before the 'show' and 'destroy' methods